### PR TITLE
feat: add OPML import command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/spf13/cobra v1.8.1
+	golang.org/x/net v0.39.0
 	modernc.org/sqlite v1.38.2
 )
 
@@ -25,7 +26,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	modernc.org/libc v1.66.10 // indirect

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -420,6 +420,34 @@ func newCategoriesCommand() *cobra.Command {
 	return cmd
 }
 
+func newImportCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import <file>",
+		Short: "Import blogs from an OPML file.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			f, err := os.Open(args[0])
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			db, err := storage.OpenDatabase("")
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			added, skipped, err := controller.ImportOPML(db, f)
+			if err != nil {
+				printError(err)
+				return markError(err)
+			}
+			color.New(color.FgGreen).Printf("Imported %d blogs, skipped %d duplicates\n", added, skipped)
+			return nil
+		},
+	}
+	return cmd
+}
+
 func newUnreadCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unread <article_id>",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -27,6 +27,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(newReadCommand())
 	rootCmd.AddCommand(newReadAllCommand())
 	rootCmd.AddCommand(newUnreadCommand())
+	rootCmd.AddCommand(newImportCommand())
 	return rootCmd
 }
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,9 +1,12 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/hanw39/blogwatcher/internal/model"
+	"github.com/hanw39/blogwatcher/internal/opml"
 	"github.com/hanw39/blogwatcher/internal/storage"
 )
 
@@ -159,6 +162,30 @@ func MarkAllArticlesRead(db *storage.Database, blogName string) ([]model.Article
 	}
 
 	return articles, nil
+}
+
+func ImportOPML(db *storage.Database, r io.Reader) (added int, skipped int, err error) {
+	feeds, err := opml.Parse(r)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, feed := range feeds {
+		siteURL := feed.SiteURL
+		if siteURL == "" {
+			siteURL = feed.FeedURL
+		}
+		_, err := AddBlog(db, feed.Title, siteURL, feed.FeedURL, "", "")
+		if err != nil {
+			var alreadyExists BlogAlreadyExistsError
+			if errors.As(err, &alreadyExists) {
+				skipped++
+				continue
+			}
+			return added, skipped, err
+		}
+		added++
+	}
+	return added, skipped, nil
 }
 
 func MarkArticleUnread(db *storage.Database, articleID int64) (model.Article, error) {

--- a/internal/opml/opml.go
+++ b/internal/opml/opml.go
@@ -1,0 +1,64 @@
+package opml
+
+import (
+	"encoding/xml"
+	"io"
+
+	"golang.org/x/net/html/charset"
+)
+
+type document struct {
+	Body body `xml:"body"`
+}
+
+type body struct {
+	Outlines []outline `xml:"outline"`
+}
+
+type outline struct {
+	Type     string    `xml:"type,attr"`
+	Text     string    `xml:"text,attr"`
+	Title    string    `xml:"title,attr"`
+	XMLURL   string    `xml:"xmlUrl,attr"`
+	HTMLURL  string    `xml:"htmlUrl,attr"`
+	Children []outline `xml:"outline"`
+}
+
+type Feed struct {
+	Title   string
+	SiteURL string
+	FeedURL string
+}
+
+func Parse(r io.Reader) ([]Feed, error) {
+	var doc document
+	dec := xml.NewDecoder(r)
+	dec.CharsetReader = charset.NewReaderLabel
+	if err := dec.Decode(&doc); err != nil {
+		return nil, err
+	}
+
+	var feeds []Feed
+	for _, o := range doc.Body.Outlines {
+		feeds = collectFeeds(feeds, o)
+	}
+	return feeds, nil
+}
+
+func collectFeeds(feeds []Feed, o outline) []Feed {
+	if o.XMLURL != "" {
+		title := o.Title
+		if title == "" {
+			title = o.Text
+		}
+		feeds = append(feeds, Feed{
+			Title:   title,
+			SiteURL: o.HTMLURL,
+			FeedURL: o.XMLURL,
+		})
+	}
+	for _, child := range o.Children {
+		feeds = collectFeeds(feeds, child)
+	}
+	return feeds
+}

--- a/internal/opml/opml_test.go
+++ b/internal/opml/opml_test.go
@@ -1,0 +1,212 @@
+package opml
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	input := `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+    <head><title>Test</title></head>
+    <body>
+        <outline text="Category1" title="Category1">
+            <outline type="rss" text="Blog One" title="Blog One" xmlUrl="http://blog1.com/feed" htmlUrl="http://blog1.com"/>
+            <outline type="rss" text="Blog Two" title="Blog Two" xmlUrl="http://blog2.com/rss" htmlUrl="http://blog2.com"/>
+        </outline>
+        <outline text="Category2" title="Category2">
+            <outline type="rss" text="Blog Three" title="Blog Three" xmlUrl="http://blog3.com/atom.xml" htmlUrl="http://blog3.com"/>
+        </outline>
+    </body>
+</opml>`
+
+	feeds, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(feeds) != 3 {
+		t.Fatalf("expected 3 feeds, got %d", len(feeds))
+	}
+
+	expected := []Feed{
+		{Title: "Blog One", SiteURL: "http://blog1.com", FeedURL: "http://blog1.com/feed"},
+		{Title: "Blog Two", SiteURL: "http://blog2.com", FeedURL: "http://blog2.com/rss"},
+		{Title: "Blog Three", SiteURL: "http://blog3.com", FeedURL: "http://blog3.com/atom.xml"},
+	}
+	for i, f := range feeds {
+		if f != expected[i] {
+			t.Errorf("feed %d: got %+v, want %+v", i, f, expected[i])
+		}
+	}
+}
+
+func TestParseEmptyCategories(t *testing.T) {
+	input := `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+    <head><title>Test</title></head>
+    <body>
+        <outline text="Empty" title="Empty"/>
+        <outline text="HasOne" title="HasOne">
+            <outline type="rss" text="Blog" title="Blog" xmlUrl="http://blog.com/feed" htmlUrl="http://blog.com"/>
+        </outline>
+        <outline text="AlsoEmpty" title="AlsoEmpty"/>
+    </body>
+</opml>`
+
+	feeds, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(feeds) != 1 {
+		t.Fatalf("expected 1 feed, got %d", len(feeds))
+	}
+	if feeds[0].Title != "Blog" {
+		t.Errorf("expected title 'Blog', got '%s'", feeds[0].Title)
+	}
+}
+
+func TestParseUsesTextWhenTitleEmpty(t *testing.T) {
+	input := `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+    <head><title>Test</title></head>
+    <body>
+        <outline text="Cat" title="Cat">
+            <outline type="rss" text="Fallback Name" xmlUrl="http://example.com/feed" htmlUrl="http://example.com"/>
+        </outline>
+    </body>
+</opml>`
+
+	feeds, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(feeds) != 1 {
+		t.Fatalf("expected 1 feed, got %d", len(feeds))
+	}
+	if feeds[0].Title != "Fallback Name" {
+		t.Errorf("expected title 'Fallback Name', got '%s'", feeds[0].Title)
+	}
+}
+
+func TestParseSkipsOutlineWithoutXmlUrl(t *testing.T) {
+	input := `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+    <head><title>Test</title></head>
+    <body>
+        <outline text="Cat" title="Cat">
+            <outline type="rss" text="No Feed" title="No Feed" htmlUrl="http://example.com"/>
+            <outline type="rss" text="Has Feed" title="Has Feed" xmlUrl="http://example.com/feed" htmlUrl="http://example.com"/>
+        </outline>
+    </body>
+</opml>`
+
+	feeds, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(feeds) != 1 {
+		t.Fatalf("expected 1 feed, got %d", len(feeds))
+	}
+	if feeds[0].Title != "Has Feed" {
+		t.Errorf("expected title 'Has Feed', got '%s'", feeds[0].Title)
+	}
+}
+
+func TestParseSubscriptionList(t *testing.T) {
+	// Based on opml.org/examples/subscriptionList.opml
+	// Flat list of RSS feeds without categories (OPML 2.0)
+	input := `<?xml version="1.0" encoding="ISO-8859-1"?>
+<opml version="2.0">
+	<head><title>mySubscriptions.opml</title></head>
+	<body>
+		<outline text="CNET News.com" description="Tech news" htmlUrl="http://news.com.com/" language="unknown" title="CNET News.com" type="rss" version="RSS2" xmlUrl="http://news.com.com/2547-1_3-0-5.xml"/>
+		<outline text="washingtonpost.com - Politics" description="Politics" htmlUrl="http://www.washingtonpost.com/wp-dyn/politics" language="unknown" title="washingtonpost.com - Politics" type="rss" version="RSS2" xmlUrl="http://www.washingtonpost.com/wp-srv/politics/rssheadlines.xml"/>
+		<outline text="Scripting News" description="It's even worse than it appears." htmlUrl="http://www.scripting.com/" language="unknown" title="Scripting News" type="rss" version="RSS2" xmlUrl="http://www.scripting.com/rss.xml"/>
+	</body>
+</opml>`
+
+	feeds, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(feeds) != 3 {
+		t.Fatalf("expected 3 feeds, got %d", len(feeds))
+	}
+	if feeds[0].Title != "CNET News.com" {
+		t.Errorf("expected 'CNET News.com', got '%s'", feeds[0].Title)
+	}
+	if feeds[0].FeedURL != "http://news.com.com/2547-1_3-0-5.xml" {
+		t.Errorf("unexpected feed URL: %s", feeds[0].FeedURL)
+	}
+	if feeds[0].SiteURL != "http://news.com.com/" {
+		t.Errorf("unexpected site URL: %s", feeds[0].SiteURL)
+	}
+}
+
+func TestParseNoFeeds(t *testing.T) {
+	// Based on opml.org/examples/states.opml — hierarchical outline with no RSS feeds
+	input := `<?xml version="1.0"?>
+<opml version="2.0">
+	<head><title>states.opml</title></head>
+	<body>
+		<outline text="United States">
+			<outline text="Far West">
+				<outline text="Alaska"/>
+				<outline text="California"/>
+			</outline>
+			<outline text="New England">
+				<outline text="Connecticut"/>
+				<outline text="Maine"/>
+			</outline>
+		</outline>
+	</body>
+</opml>`
+
+	feeds, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(feeds) != 0 {
+		t.Fatalf("expected 0 feeds from states outline, got %d", len(feeds))
+	}
+}
+
+func TestParseDirectoryLinks(t *testing.T) {
+	// Based on opml.org/examples/directory.opml — type="link" outlines, no xmlUrl
+	input := `<?xml version="1.0" encoding="ISO-8859-1"?>
+<opml version="2.0">
+	<head><title>scriptingNewsDirectory.opml</title></head>
+	<body>
+		<outline text="Scripting News sites" type="link" url="http://hosting.opml.org/dave/mySites.opml"/>
+		<outline text="News.Com top 100 OPML" type="link" url="http://news.com.com/html/ne/blogs/CNETNewsBlog100.opml"/>
+		<outline text="TechCrunch reviews" type="link" url="http://hosting.opml.org/techcrunch.opml.org/TechCrunch.opml"/>
+	</body>
+</opml>`
+
+	feeds, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(feeds) != 0 {
+		t.Fatalf("expected 0 feeds from directory links, got %d", len(feeds))
+	}
+}
+
+func TestParseCategoryAttribute(t *testing.T) {
+	// Based on opml.org/examples/category.opml
+	input := `<?xml version="1.0" encoding="ISO-8859-1"?>
+<opml version="2.0">
+	<head><title>Illustrating the category attribute</title></head>
+	<body>
+		<outline text="The Mets are the best team in baseball." category="/Philosophy/Baseball/Mets,/Tourism/New York"/>
+	</body>
+</opml>`
+
+	feeds, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(feeds) != 0 {
+		t.Fatalf("expected 0 feeds from category example, got %d", len(feeds))
+	}
+}


### PR DESCRIPTION
Add `blogwatcher import <file>` command to bulk-import blog subscriptions from OPML files (e.g. Feedly, Inoreader exports). The parser handles OPML 1.0/2.0, non-UTF-8 encodings (ISO-8859-1), nested categories, and gracefully skips non-feed outlines (links, directories, plain text). Duplicate blogs are counted and reported rather than causing errors.